### PR TITLE
Add plugin logic to OrderAddressWriter

### DIFF
--- a/src/FondOfSpryker/Zed/Sales/Business/Address/OrderAddressWriter.php
+++ b/src/FondOfSpryker/Zed/Sales/Business/Address/OrderAddressWriter.php
@@ -11,6 +11,7 @@ class OrderAddressWriter implements OrderAddressWriterInterface
      * @var \FondOfSpryker\Zed\SalesExtension\Dependency\Plugin\OrderAddressExpanderPluginInterface[]
      */
     protected $orderAddressExpanderPlugins;
+
     /**
      * @var \Spryker\Zed\Sales\Business\Address\OrderAddressWriterInterface
      */
@@ -18,7 +19,7 @@ class OrderAddressWriter implements OrderAddressWriterInterface
 
     /**
      * @param \Spryker\Zed\Sales\Business\Address\OrderAddressWriterInterface $orderAddressWriter
-     * @param array $orderAddressExpanderPlugins
+     * @param \FondOfSpryker\Zed\SalesExtension\Dependency\Plugin\OrderAddressExpanderPluginInterface[] $orderAddressExpanderPlugins
      */
     public function __construct(
         OrderAddressWriterInterface $orderAddressWriter,

--- a/src/FondOfSpryker/Zed/Sales/Business/Address/OrderAddressWriter.php
+++ b/src/FondOfSpryker/Zed/Sales/Business/Address/OrderAddressWriter.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace FondOfSpryker\Zed\Sales\Business\Address;
+
+use Generated\Shared\Transfer\AddressTransfer;
+use Spryker\Zed\Sales\Business\Address\OrderAddressWriterInterface;
+
+class OrderAddressWriter implements OrderAddressWriterInterface
+{
+    /**
+     * @var \FondOfSpryker\Zed\SalesExtension\Dependency\Plugin\OrderAddressExpanderPluginInterface[]
+     */
+    protected $orderAddressExpanderPlugins;
+    /**
+     * @var \Spryker\Zed\Sales\Business\Address\OrderAddressWriterInterface
+     */
+    protected $orderAddressWriter;
+
+    /**
+     * @param \Spryker\Zed\Sales\Business\Address\OrderAddressWriterInterface $orderAddressWriter
+     * @param array $orderAddressExpanderPlugins
+     */
+    public function __construct(
+        OrderAddressWriterInterface $orderAddressWriter,
+        array $orderAddressExpanderPlugins
+    ) {
+        $this->orderAddressExpanderPlugins = $orderAddressExpanderPlugins;
+        $this->orderAddressWriter = $orderAddressWriter;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\AddressTransfer $addressTransfer
+     *
+     * @return \Generated\Shared\Transfer\AddressTransfer
+     */
+    public function create(AddressTransfer $addressTransfer): AddressTransfer
+    {
+        foreach ($this->orderAddressExpanderPlugins as $plugin) {
+            $addressTransfer = $plugin->expand($addressTransfer);
+        }
+
+        return $this->orderAddressWriter->create($addressTransfer);
+    }
+
+    public function update(AddressTransfer $addressTransfer, int $idAddress): bool
+    {
+        return $this->orderAddressWriter->update($addressTransfer, $idAddress);
+    }
+}

--- a/src/FondOfSpryker/Zed/Sales/Business/SalesBusinessFactory.php
+++ b/src/FondOfSpryker/Zed/Sales/Business/SalesBusinessFactory.php
@@ -2,9 +2,12 @@
 
 namespace FondOfSpryker\Zed\Sales\Business;
 
+use FondOfSpryker\Zed\Sales\Business\Address\OrderAddressWriter;
 use FondOfSpryker\Zed\Sales\Business\Model\Order\OrderReferenceGenerator;
 use FondOfSpryker\Zed\Sales\Business\Model\Order\SalesOrderSaver;
 use FondOfSpryker\Zed\Sales\SalesDependencyProvider;
+use Spryker\Zed\Sales\Business\Address\OrderAddressWriter as SprykerOrderAddressWriter;
+use Spryker\Zed\Sales\Business\Address\OrderAddressWriterInterface;
 use Spryker\Zed\Sales\Business\Model\Order\OrderReferenceGeneratorInterface;
 use Spryker\Zed\Sales\Business\Model\Order\SalesOrderSaverInterface;
 use Spryker\Zed\Sales\Business\SalesBusinessFactory as SprykerSalesBusinessFactory;
@@ -54,4 +57,25 @@ class SalesBusinessFactory extends SprykerSalesBusinessFactory
             $this->getConfig()
         );
     }
+
+    /**
+     * @return \Spryker\Zed\Sales\Business\Address\OrderAddressWriterInterface
+     */
+    public function createOrderAddressWriter(): OrderAddressWriterInterface
+    {
+        $spyOrderAddressWriter = new SprykerOrderAddressWriter($this->getEntityManager(), $this->getCountryFacade());
+        return new OrderAddressWriter(
+            $spyOrderAddressWriter,
+            $this->getOrderAddressExpanderPlugins()
+        );
+    }
+
+    /**
+     * @return \FondOfSpryker\Zed\SalesExtension\Dependency\Plugin\OrderAddressExpanderPluginInterface[]
+     */
+    private function getOrderAddressExpanderPlugins(): array
+    {
+        return $this->getProvidedDependency(SalesDependencyProvider::PLUGINS_ORDER_ADDRESS_EXPANDER);
+    }
+
 }

--- a/src/FondOfSpryker/Zed/Sales/SalesDependencyProvider.php
+++ b/src/FondOfSpryker/Zed/Sales/SalesDependencyProvider.php
@@ -8,6 +8,7 @@ use Spryker\Zed\Sales\SalesDependencyProvider as SprykerSalesDependencyProvider;
 class SalesDependencyProvider extends SprykerSalesDependencyProvider
 {
     public const PLUGINS_SALES_ORDER_ADDRESS_HYDRATION = 'PLUGINS_SALES_ORDER_ADDRESS_HYDRATION';
+    public const PLUGINS_ORDER_ADDRESS_EXPANDER = 'PLUGINS_ORDER_ADDRESS_EXPANDER';
 
     /**
      * @param \Spryker\Zed\Kernel\Container $container
@@ -19,6 +20,7 @@ class SalesDependencyProvider extends SprykerSalesDependencyProvider
         $container = parent::provideBusinessLayerDependencies($container);
 
         $container = $this->addSalesOrderAddressHydrationPlugins($container);
+        $container = $this->addOrderAddressExpanderPlugins($container);
 
         return $container;
     }
@@ -40,9 +42,33 @@ class SalesDependencyProvider extends SprykerSalesDependencyProvider
     }
 
     /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addOrderAddressExpanderPlugins(Container $container): Container
+    {
+        $self = $this;
+
+        $container[static::PLUGINS_ORDER_ADDRESS_EXPANDER] = static function () use ($self) {
+            return $self->getOrderAddressExpanderPlguins();
+        };
+
+        return $container;
+    }
+
+    /**
      * @return \FondOfSpryker\Zed\SalesExtension\Dependency\Plugin\SalesOrderAddressHydrationPluginInterface[]
      */
     protected function getSalesOrderAddressHydrationPlugins(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return \FondOfSpryker\Zed\SalesExtension\Dependency\Plugin\OrderAddressExpanderPluginInterface[]
+     */
+    protected function getOrderAddressExpanderPlguins(): array
     {
         return [];
     }

--- a/tests/FondOfSpryker/Zed/Sales/Business/Address/OrderAddressWriterTest.php
+++ b/tests/FondOfSpryker/Zed/Sales/Business/Address/OrderAddressWriterTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace FondOfSpryker\Zed\Sales\Business\Address;
+
+use Codeception\Test\Unit;
+use FondOfSpryker\Zed\SalesRegionConnector\Communication\Plugin\SalesExtension\RegionOrderAddressExpanderPlugin;
+use Generated\Shared\Transfer\AddressTransfer;
+use Spryker\Zed\Sales\Business\Address\OrderAddressWriter as SprykerOrderAddressWriter;
+
+class OrderAddressWriterTest extends Unit
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $addressTransferMock;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $sprykerOrderAddressWriterMock;
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $orderAddressExpanderPluginMock;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->addressTransferMock = $this->getMockBuilder(AddressTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->sprykerOrderAddressWriterMock = $this->getMockBuilder(SprykerOrderAddressWriter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->orderAddressExpanderPluginMock = $this->getMockBuilder(RegionOrderAddressExpanderPlugin::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateWithoutPlugins(): void
+    {
+        $orderAddressWriter = new OrderAddressWriter(
+            $this->sprykerOrderAddressWriterMock,
+            []
+        );
+
+         $this->sprykerOrderAddressWriterMock
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($this->addressTransferMock);
+
+        $addressTransfer = $orderAddressWriter->create($this->addressTransferMock);
+
+        $this->assertEquals($this->addressTransferMock, $addressTransfer);
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateWithPlugins(): void
+    {
+        $this->orderAddressExpanderPluginMock->expects($this->once())
+            ->method('expand')
+            ->with($this->addressTransferMock)
+            ->willReturn($this->addressTransferMock);
+
+        $orderAddressWriter = new OrderAddressWriter(
+            $this->sprykerOrderAddressWriterMock,
+            [ $this->orderAddressExpanderPluginMock ]
+        );
+
+        $this->sprykerOrderAddressWriterMock
+            ->expects($this->once())
+            ->method('create')
+            ->willReturn($this->addressTransferMock);
+
+        $addressTransfer = $orderAddressWriter->create($this->addressTransferMock);
+
+        $this->assertEquals($this->addressTransferMock, $addressTransfer);
+    }
+
+    /**
+     * @return void
+     */
+    public function testUpdate(): void
+    {
+        $orderAddressWriter = new OrderAddressWriter(
+            $this->sprykerOrderAddressWriterMock,
+            []
+        );
+
+        $this->sprykerOrderAddressWriterMock
+            ->expects($this->once())
+            ->method('update')
+            ->willReturn(true);
+
+        $updated = $orderAddressWriter->update($this->addressTransferMock, 1);
+
+        $this->assertEquals(true, $updated);
+    }
+}


### PR DESCRIPTION
This will allow to use https://github.com/fond-of/spryker-sales-extension/pull/1 to create plugins which can manipulate the oder address on an item level before storing it to persistence.